### PR TITLE
Add dataLayer event property

### DIFF
--- a/packages/google-tag-manager/plugin.js
+++ b/packages/google-tag-manager/plugin.js
@@ -7,6 +7,6 @@ window['<%= options.layer %>'].push({
 // Every time the route changes (fired on initialization too)
 export default ({app: {router}}) => {
   router.afterEach((to, from) => {
-    window['<%= options.layer %>'].push(to.gtm || {pageType: 'PageView', pageUrl: to.fullPath})
+    window['<%= options.layer %>'].push(to.gtm || {event: 'nuxtRoute', pageType: 'PageView', pageUrl: to.fullPath})
   })
 }


### PR DESCRIPTION
By naming the push event it allows users to trigger GTM tags based on each route change such as integrating Google Analytics via Google Tag Manager.

Without this, there is no way to trigger any actions within GTM based on a route change within a Nuxt app.

[Tag Manager Docs on pushing Events](https://developers.google.com/tag-manager/devguide#events)